### PR TITLE
If 'no expectations' warning is suppressed - do not show a warning in…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastmarkets-fusion/karma-jasmine-html-reporter",
-  "version": "1.4.1",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastmarkets-fusion/karma-jasmine-html-reporter",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A Karma plugin. Dynamically displays tests results at debug.html page. Fork of https://github.com/dfederm/karma-jasmine-html-reporter v1.4.0",
   "main": "./src/index.js",
   "keywords": [

--- a/src/lib/html.jasmine.reporter.js
+++ b/src/lib/html.jasmine.reporter.js
@@ -322,7 +322,7 @@ jasmineRequire.HtmlReporter = function (j$) {
             domParent.appendChild(specListNode);
           }
           var specDescription = resultNode.result.description;
-          if (noExpectations(resultNode.result)) {
+          if (!suppressNoExpectationsWarning && noExpectations(resultNode.result)) {
             specDescription = 'SPEC HAS NO EXPECTATIONS ' + specDescription;
           }
           if (resultNode.result.status === 'pending' && resultNode.result.pendingReason !== '') {


### PR DESCRIPTION
I came across an issue that even though the warning had been suppressed, HTML reporter still displayed that warning in the spec's description block like this:

> AuthCallbackComponent
> - SPEC HAS NO EXPECTATIONS should create
> - SPEC HAS NO EXPECTATIONS should call auth-service

So I've disabled it as well for consistency and in case you didn't leave them intentionally, I'm proposing to have the PR included.

